### PR TITLE
Fix shutdown cmd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "peach-menu"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Andrew Reid <gnomad@cryptolab.net>"]
 edition = "2018"
 description = "Menu for monitoring and interacting with the PeachCloud device. A state machine which listens for GPIO events (button presses) by subscribing to peach-buttons over websockets and makes JSON-RPC calls to relevant PeachCloud microservices."

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peach-menu
 
-[![Build Status](https://travis-ci.com/peachcloud/peach-menu.svg?branch=master)](https://travis-ci.com/peachcloud/peach-menu) ![Generic badge](https://img.shields.io/badge/version-0.2.0-<COLOR>.svg)
+[![Build Status](https://travis-ci.com/peachcloud/peach-menu.svg?branch=master)](https://travis-ci.com/peachcloud/peach-menu) ![Generic badge](https://img.shields.io/badge/version-0.2.1-<COLOR>.svg)
 
 OLED menu microservice module for PeachCloud. A state machine which listens for GPIO events (button presses) by subscribing to `peach-buttons` over websockets and makes [JSON-RPC](https://www.jsonrpc.org/specification) calls to relevant PeachCloud microservices (`peach-network`, `peach-oled`, `peach-stats`).
 
@@ -79,7 +79,7 @@ Build the package:
 
 `cargo deb`
 
-The output will be written to `target/debian/peach-menu_0.1.0_arm64.deb` (or similar).
+The output will be written to `target/debian/peach-menu_0.2.1_arm64.deb` (or similar).
 
 Build the package (aarch64):
 
@@ -87,7 +87,7 @@ Build the package (aarch64):
 
 Install the package as follows:
 
-`sudo dpkg -i target/debian/peach-menu_0.1.0_arm64.deb`
+`sudo dpkg -i target/debian/peach-menu_0.2.1_arm64.deb`
 
 The service will be automatically enabled and started.
 

--- a/src/states.rs
+++ b/src/states.rs
@@ -251,7 +251,7 @@ pub fn state_reboot() -> Result<(), MenuError> {
     oled_power(false)?;
     info!("Rebooting device");
     process::Command::new("sudo")
-        .arg("shutdown")
+        .arg("/sbin/shutdown")
         .arg("-r")
         .arg("now")
         .output()
@@ -273,7 +273,7 @@ pub fn state_shutdown() -> Result<(), MenuError> {
     oled_power(false)?;
     info!("Shutting down device");
     process::Command::new("sudo")
-        .arg("shutdown")
+        .arg("/sbin/shutdown")
         .arg("now")
         .output()
         .expect("Failed to shutdown");


### PR DESCRIPTION
Include absolute path for initiating the shutdown and reboot commands from the menu.