### PR TITLE
Remove systemd protections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "peach-menu"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/debian/peach-menu.service
+++ b/debian/peach-menu.service
@@ -10,21 +10,6 @@ Restart=always
 Wants=peach-network.service peach-stats.service
 Requires=peach-buttons.service peach-oled.service
 After=peach-buttons.service peach-oled.service peach-network.service peach-stats.service
-CapabilityBoundingSet=~CAP_SYS_ADMIN CAP_SYS_PTRACE CAP_SYS_BOOT CAP_SYS_TIME CAP_KILL CAP_WAKE_ALARM CAP_LINUX_IMMUTABLE CAP_BLOCK_SUSPEND CAP_LEASE CAP_SYS_NICE CAP_SYS_RESOURCE CAP_RAWIO CAP_CHOWN CAP_FSETID CAP_SETFCAP CAP_DAC_* CAP_FOWNER CAP_IPC_OWNER CAP_SETUID CAP_SETGID CAP_SETPCAP CAP_AUDIT_*
-InaccessibleDirectories=/home
-LockPersonality=yes
-NoNewPrivileges=yes
-PrivateDevices=yes
-PrivateTmp=yes
-PrivateUsers=yes
-ProtectControlGroups=yes
-ProtectHome=yes
-ProtectKernelModules=yes
-ProtectKernelTunables=yes
-ProtectSystem=yes
-ReadOnlyDirectories=/var
-RestrictAddressFamilies=~AF_INET6 AF_UNIX
-SystemCallFilter=~@reboot @clock @debug @module @mount @swap @resources @privileged
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Bump lock file and remove systemd capability restrictions and other protections. The restrictions were preventing the `peach-menu` service from initiating system reboot and shutdown.

I've tried to identify the offending protections but have opted to remove them all for now. Will return to this at a later time.