### PR TITLE
Remove extern statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # peach-menu
 
-[![Build Status](https://travis-ci.com/peachcloud/peach-menu.svg?branch=master)](https://travis-ci.com/peachcloud/peach-menu) ![Generic badge](https://img.shields.io/badge/version-0.2.1-<COLOR>.svg)
+[![Build Status](https://travis-ci.com/peachcloud/peach-menu.svg?branch=master)](https://travis-ci.com/peachcloud/peach-menu) ![Generic badge](https://img.shields.io/badge/version-0.2.2-<COLOR>.svg)
 
 OLED menu microservice module for PeachCloud. A state machine which listens for GPIO events (button presses) by subscribing to `peach-buttons` over websockets and makes [JSON-RPC](https://www.jsonrpc.org/specification) calls to relevant PeachCloud microservices (`peach-network`, `peach-oled`, `peach-stats`).
 

--- a/src/buttons.rs
+++ b/src/buttons.rs
@@ -1,10 +1,8 @@
-extern crate ws;
-
 use std::process;
 
+use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-
 use ws::{CloseCode, Error, Handler, Handshake, Message, Sender};
 
 #[derive(Debug, Deserialize)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,3 @@
-extern crate jsonrpc_client_core;
-extern crate jsonrpc_client_http;
-
 #[derive(Debug)]
 pub enum MenuError {
     OledHttp(jsonrpc_client_http::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,13 +5,6 @@
 //! with `peach-buttons` providing GPIO input data and `peach-oled` receiving
 //! output data for display.
 //!
-#[macro_use]
-pub extern crate log;
-extern crate crossbeam_channel;
-#[macro_use]
-extern crate jsonrpc_client_core;
-extern crate ws;
-
 pub mod buttons;
 mod error;
 pub mod network;
@@ -24,7 +17,7 @@ mod structs;
 use std::env;
 
 use crossbeam_channel::unbounded;
-
+use log::{debug, info};
 use ws::connect;
 
 use crate::buttons::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,6 @@
-extern crate peach_menu;
-#[macro_use]
-extern crate log;
-extern crate env_logger;
+use std::process;
 
-use ::std::process;
+use log::error;
 
 fn main() {
     // initialize the logger

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,8 +1,8 @@
-extern crate jsonrpc_client_http;
-
 use std::env;
 
+use jsonrpc_client_core::*;
 use jsonrpc_client_http::HttpTransport;
+use log::{debug, info};
 
 use crate::error::MenuError;
 use crate::structs::Traffic;

--- a/src/oled.rs
+++ b/src/oled.rs
@@ -1,8 +1,8 @@
-extern crate jsonrpc_client_http;
-
 use std::env;
 
+use jsonrpc_client_core::*;
 use jsonrpc_client_http::HttpTransport;
+use log::{debug, info};
 
 use crate::error::MenuError;
 

--- a/src/state_machine.rs
+++ b/src/state_machine.rs
@@ -1,9 +1,7 @@
-extern crate crossbeam_channel;
-extern crate ws;
-
 use std::{process, thread};
 
 use crossbeam_channel::*;
+use log::{error, info, warn};
 
 use crate::error::MenuError;
 use crate::oled::*;

--- a/src/states.rs
+++ b/src/states.rs
@@ -1,6 +1,7 @@
-use chrono::{DateTime, Local};
-
 use std::{process, thread, time};
+
+use chrono::{DateTime, Local};
+use log::info;
 
 use crate::error::MenuError;
 use crate::network::*;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,8 +1,8 @@
-extern crate jsonrpc_client_http;
-
 use std::env;
 
+use jsonrpc_client_core::*;
 use jsonrpc_client_http::HttpTransport;
+use log::{debug, info};
 
 use crate::error::MenuError;
 use crate::structs::{CpuStatPercentages, LoadAverage, MemStat, Uptime};


### PR DESCRIPTION
Remove `extern` statements and replace with `use` where required.